### PR TITLE
fix: Display System Name in Admin Product Attribute Dropdown

### DIFF
--- a/client/pages/AdminDashboard.tsx
+++ b/client/pages/AdminDashboard.tsx
@@ -8863,11 +8863,8 @@ const AdminDashboard: React.FC = () => {
                                   <div className="flex items-center justify-between">
                                     <div>
                                       <h4 className="font-medium text-cream-900">
-                                        {attrType.attributeName}
+                                        {attrType.systemName} {attrType.attributeName ? `(${attrType.attributeName})` : ''}
                                       </h4>
-                                      <h3 className="text-xs text-cream-600 mt-1">
-                                        {attrType.systemName}
-                                      </h3>
                                       <p className="text-xs text-cream-600 mt-1">
                                         {attrType.inputStyle || "N/A"} • {attrType.primaryEffectType || "N/A"} •{" "}
                                         {attrType.isPricingAttribute ? "Affects Price" : "No Price Impact"}


### PR DESCRIPTION
Fixes #11

- Changed attribute dropdown to display systemName instead of attributeName
- Format: 'systemName (Display Name)' for better clarity
- Ensures admins can distinguish between attributes with same Display Name

This resolves the UX issue where admins couldn't differentiate between attributes that share the same customer-facing name but have different internal purposes (system names).

Example: size_business_card (Size) instead of just 'Size'